### PR TITLE
Add package description metadata to allow package installation

### DIFF
--- a/music-chord.el
+++ b/music-chord.el
@@ -1,4 +1,16 @@
-;;; music-chord --- major mode for text files containing musical chords
+;;; music-chord.el --- major mode for text files containing musical chords
+
+;; Copyright (C) 2018 Wouter Bolsterlee
+
+;; Author: Wouter Bolsterlee <wouter@bolsterl.ee>
+;; URL: https://github.com/wbolster/emacs-music-chord
+;; Package-Version: 0.1.0
+;; Keywords: lisp music songwriting
+;; Version: 0.1.0
+
+;; This file is NOT part of GNU Emacs.
+
+;;; License:
 
 ;;; Commentary:
 


### PR DESCRIPTION
Currently the installation of package is failing when trying to install with
quelpa. Adding this metadata in file, allows installation of the music-chord
package.

Also thanks for this neat package, I am using it for songwriting. 
I was surprised with lack thereof for songwriting packages in emacs, 
finally stumbled upon your package. It suits my requirement very well.

Please consider adding a License section per your liking. 
I can also help to push this in MELPA or something, I haven't done that before, but I can figure it out.